### PR TITLE
update data structure handling - saving grid responses

### DIFF
--- a/questionnaire.js
+++ b/questionnaire.js
@@ -363,7 +363,7 @@ export function isFirstQuestion() {
 
 /**
  * Determine the storage format for the response data.
- * Grid questions and questions with multiple response inputs are stored as objects. Ensure each key is stored with the response.
+ * Grid questions are stored as objects. Ensure each key is stored with the response.
  * Single response (radio) input questions are stored as primitives.
  * Multi-selection (checkbox) input questions are stored as arrays.
  * @param {HTMLElement} form - the form element being evaluated.
@@ -386,10 +386,11 @@ function isObjectStore(form) {
 }
 
 function setFormValue(form, value, id) {
-
-  if (value === "") {
-    value = undefined
+  if (value === "" || Array.isArray(value) && value.length === 0) {
+    value = undefined;
   }
+
+  if (!id || id.trim() === "") return;
 
   if (!isObjectStore(form)) {
     form.value = value;
@@ -927,8 +928,10 @@ async function nextPage(norp, retrieve, store, rootElement) {
     try {
       // show a loading indicator for variables in delayedParameterArray (they take extra time to process)
       if (moduleParams.delayedParameterArray.includes(nextElement.id)) showLoadingIndicator();
+
       let formData = {};
       formData[`${questName}.${questionElement.id}`] = questionElement.value;
+      console.log(formData)
       await store(formData)
     } catch (e) {
       console.error("Store failed", e);
@@ -1089,7 +1092,11 @@ export function displayQuestion(nextElement) {
     console.log(`checking the datagrid for displayif... ${elm.dataset.questionId} ${f}`)
 
     if (f !== true) {
-      elm.remove();
+      elm.dataset.hidden = "true";
+      elm.style.display = "none";
+    } else {
+      delete elm.dataset.hidden;
+      elm.style.display = "";
     }
   });
 

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -595,7 +595,6 @@ export function radioAndCheckboxClearTextInput(inputElement) {
 export function radioAndCheckboxUpdate(inputElement) {
   if (!inputElement) return;
   clearSelection(inputElement);
-  console.log('radioAndCheckboxUpdate', inputElement)
 
   let selectedValue = {};
   if (inputElement.type == "checkbox") {
@@ -611,8 +610,6 @@ export function radioAndCheckboxUpdate(inputElement) {
     // we have a radio button..  just get the selected value...
     selectedValue = inputElement.value;
   }
-
-  console.log('selectedValue', selectedValue);
 
   setFormValue(inputElement.form, selectedValue, inputElement.name);
 }
@@ -879,7 +876,6 @@ async function nextPage(norp, retrieve, store, rootElement) {
     x.value = "true"
     setFormValue(questionElement, x.value, x.id)
   });
-  console.log("questionElement: ", questionElement);
 
   if (checkValid(questionElement) == false) {
     return null;
@@ -895,10 +891,8 @@ async function nextPage(norp, retrieve, store, rootElement) {
   checkForSkips(questionElement);
 
   let nextQuestionId = getNextQuestionId(questionElement);
-  console.log('nextQuestionId: ', nextQuestionId);
   // get the actual HTML element.
   let nextElement = document.getElementById(nextQuestionId.value);
-  console.log("nextElement: ", nextElement);
   nextElement = exitLoop(nextElement);
 
   // before we add the next question to the queue...
@@ -907,7 +901,6 @@ async function nextPage(norp, retrieve, store, rootElement) {
     // not sure what to do if the next element is is not a question ...
     if (nextElement.classList.contains("question")) {
       let display = evaluateCondition(nextElement.getAttribute("displayif"));
-      console.log("displayif: ", display);
       if (display) break;
       if (nextElement.id.substring(0, 9) != "_CONTINUE") questionQueue.pop();
 
@@ -918,7 +911,6 @@ async function nextPage(norp, retrieve, store, rootElement) {
       nextQuestionId = getNextQuestionId(nextElement);
 
       nextElement = document.getElementById(nextQuestionId.value);
-      console.log("nextElement (while loop): ", nextElement);
       nextElement = exitLoop(nextElement);
     } else {
       console.log(
@@ -935,10 +927,8 @@ async function nextPage(norp, retrieve, store, rootElement) {
     try {
       // show a loading indicator for variables in delayedParameterArray (they take extra time to process)
       if (moduleParams.delayedParameterArray.includes(nextElement.id)) showLoadingIndicator();
-      console.log('questionElement.id: ', questionElement.id, 'questionElement.value: ', questionElement.value);
       let formData = {};
       formData[`${questName}.${questionElement.id}`] = questionElement.value;
-      console.log(formData)
       await store(formData)
     } catch (e) {
       console.error("Store failed", e);
@@ -1058,7 +1048,6 @@ export function displayQuestion(nextElement) {
   // check all responses for next question
   [...nextElement.querySelectorAll('[displayif]')].map((elm) => {
     let f = evaluateCondition(elm.getAttribute("displayif"));
-    console.log('DISPLAYIF', elm, f);
     elm.style.display = f ? null : "none";
   });
 
@@ -1087,25 +1076,20 @@ export function displayQuestion(nextElement) {
   // ISSUE: 403
   // update {$e:}/{$u} and and {$} elements in grids when the user displays the question ...
   Array.from(nextElement.querySelectorAll("[data-gridreplace]")).forEach((e) => {
-    console.log('GRIDREPLACE', e)
     if (e.dataset.gridreplacetype == "_val") {
       e.innerText = math._value(decodeURIComponent(e.dataset.gridreplace))
     } else {
       e.innerText = math.evaluate(decodeURIComponent(e.dataset.gridreplace))
     }
   });
-
-  //console.log('NEXT ELEMENT', nextElement);
   
   // Check if grid elements need to be shown. Elm is a <tr>. If f !== true, remove the row (elm) from the DOM.
   Array.from(nextElement.querySelectorAll("[data-gridrow][data-displayif]")).forEach((elm) => {
-    console.log('GRIDROW-ELM', elm)
     const f = evaluateCondition(decodeURIComponent(elm.dataset.displayif));
     console.log(`checking the datagrid for displayif... ${elm.dataset.questionId} ${f}`)
 
     if (f !== true) {
       elm.remove();
-      //elm.closest('tr').remove(); // this is the same as elm.remove()...slower but more flexible. temp leaving in case there are cases I've missed.
     }
   });
 
@@ -1412,7 +1396,6 @@ function checkValid(questionElement) {
   if (questionElement.classList.contains("invalid")) {
     return false;
   } else {
-    console.log("checking for validity:", questionElement.checkValidity());
     return questionElement.checkValidity();
   }
 }


### PR DESCRIPTION
Update grid saving operations:

•Single question grids were saving responses without the key (saving the response value only). This fixes those operations to ensure they're saved as a key-value pair.

•Displayif grid cases were being removed from the DOM entirely, so going back and changing a grid response wasn't displaying the followup displayif grid question. This updates the `remove` behavior to visibility toggling for the expected user experience. 