### PR TITLE
Grid Display-If Bug Fix

### DIFF
--- a/questionnaire.js
+++ b/questionnaire.js
@@ -1513,7 +1513,7 @@ export function evaluateCondition(txt) {
       if (typeof x === "string") {
         let element = document.getElementById(x);
         if (element != null) {
-          if (element.hasAttribute('grid') && (element.type === "radio" || element.type === "checkbox")) {
+          if (element.dataset.grid && (element.type === "radio" || element.type === "checkbox")) {
             //for displayif conditions with grid elements
             x = element.checked ? 1 : 0;
           }


### PR DESCRIPTION
This PR addresses the following Issue:
* https://github.com/episphere/connect/issues/1069
-----
## Background Details
* Follow-Up questions aren't being triggered when dependent on display-if functionality pointed at grid responses
* Updates were made to grids awhile back that changed to using datasets instead of attributes
-----
## Technical Changes
* Updated `hasAttribute()` call to `dataset.grid` inside of `evaluateCondition()`