### PR TITLE
Mod 1 & COVID survey testing updates

### DIFF
--- a/Quest.css
+++ b/Quest.css
@@ -66,15 +66,31 @@ input[type="checkbox"].form-check-input{
 }
 
 .popover-dismiss {
-  background: linear-gradient(
-    rgb(240, 173, 78),
-    rgb(240, 173, 78)
-  ) !important;
-  border: 1px solid rgb(175, 175, 175) !important;
-  padding-top: 3px !important;
-  padding-bottom: 3px !important;
+  background: #1c5d86;
+  color: white;
+  cursor: pointer;
+  border: none;
+  text-align: center;
+  text-decoration: none;
 }
 
+.popover-dismiss:hover,
+.popover-dismiss:focus {
+  background-color: #0056b3;
+  color: white;
+  text-decoration: none;
+}
+
+.popover-header {
+  background-color: #f8f9fa;
+  border-bottom: 1px solid #e9ecef;
+  font-weight: bold;
+}
+
+.popover-body {
+  color: #212529;
+  font-size: 0.9rem;
+}
 
 .text-baskerville {
   font-family: 'Libre Baskerville', serif;

--- a/customMathJSImplementation.js
+++ b/customMathJSImplementation.js
@@ -58,7 +58,6 @@ export const customMathJSFunctions = {
     if (typeof x === 'number') return true;
 
     if (x.toString().includes('.')) {
-      console.warn('EXISTS - X toString INCLUDES .', x);
       return !math.isUndefined(this.getKeyedValue(x));
     }
     
@@ -95,13 +94,24 @@ export const customMathJSFunctions = {
   },
 
   getKeyedValue: function(x) {
+    // handle keys with dot notation. E.g. valueOrDefault("D_378988419.D_807765962")
+    if (!x.toString().includes('.')) {
+      console.error('invalid use of getKeyedValue (called on key without dot notation');
+      return undefined;
+    }
+    
+    // Skip sentences and other non-key values such as multi-sentence survey text & responses
+    if (!/^[A-Za-z0-9_.]+$/.test(x)) {
+      return undefined;
+    }
+
     const array = x.toString().split('.');
     const key = array.shift();
     const obj = this._value(key);
     
     // Return early if the initial object is undefined
     if (math.isUndefined(obj)) return undefined;
-    
+
     return array.reduce((prev, curr) => {
       if (math.isUndefined(prev)) return undefined;
       return prev[curr] ?? undefined;

--- a/questionProcessor.js
+++ b/questionProcessor.js
@@ -194,11 +194,6 @@ export class QuestionProcessor {
       otherElement.dataset.confirmationFor = element.id;
     });
 
-    // enable all popovers...
-    [...newQuestionEle.querySelectorAll('[data-bs-toggle="popover"]')].forEach(popoverTriggerEl => {
-      new bootstrap.Popover(popoverTriggerEl);
-    });
-
     // remove the first 'previous' button and the final 'next' button.
     if (isFirstQuestion) {
       newQuestionEle.querySelector(".previous").remove();
@@ -766,7 +761,7 @@ export class QuestionProcessor {
     function fPopover(fullmatch, buttonText, title, popText) {
       title = title ? title : "";
       popText = popText.replace(/"/g, "&quot;")
-      return `<a tabindex="0" class="popover-dismiss btn" role="button" title="${title}" data-toggle="popover" data-bs-toggle="popover" data-trigger="focus" data-bs-trigger="focus" data-content="${popText}" data-bs-content="${popText}">${buttonText}</a>`;
+      return `<a tabindex="0" class="popover-dismiss btn" role="button" title="${title}" data-bs-toggle="popover" data-bs-trigger="focus" data-bs-content="${popText}">${buttonText}</a>`;
     }
 
     // replace |hidden|value| 

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -311,8 +311,22 @@ const handleForIDAttributes = (forIDElementArray) => {
   }
 }
 
+/**
+ * Used with forid attributes only. Toggle the forId element's visibility based on the found forid value.
+ * If a conceptID is found, the forid element should remain visible and return an empty string.
+ * Note: forid should remain visible if a concept ID is found to prevent the 'Other' input from disappearing.
+ * @param {HTMLElement} forIDElement - the element to toggle visibility.
+ * @param {string} foundValue - the value found in the state manager.
+ */
+
 const toggleElementVisibility = (forIDElement, foundValue) => {
   if (foundValue) {
+    // Return empty string for concept IDs. Case: 'Other' input with no response.
+    // Example: COVID survey - empty 'Other' input for vaccine manufacturer.
+    if (/^\d{9}$/.test(foundValue)) {
+      foundValue = ''
+    }
+
     forIDElement.style.display = null;
     forIDElement.textContent = foundValue;
   } else {
@@ -800,6 +814,9 @@ export function showAllQuestions(allProcessedQuestionsMap) {
   modalEle
     ? questDiv.insertBefore(fragment, modalEle)
     : questDiv.appendChild(fragment);
+
+  // Popovers get initialized last, after all other DOM and accessibility operations, to ensure they are in the DOM and visible (Bootstrap 5 requirement).
+  initializePopovers();
 }
 
 // Manage the text builder for screen readers (only build when necessary)
@@ -859,6 +876,9 @@ export async function prepareQuestionDOM(questionElement) {
     
     handleQuestionBRElements(questionElement);
   }
+  
+  // Popovers get initialized last, after all other DOM and accessibility operations, to ensure they are in the DOM and visible (Bootstrap 5 requirement).
+  initializePopovers();
 }
 
 /**
@@ -1135,6 +1155,21 @@ function handleUserScrollLocation() {
 
 export function isMobileDevice() {
   return window.matchMedia('(max-width: 576px)').matches;
+}
+
+/**
+ * Initialize the popovers in the questionnaire after they are appended to the DOM.
+ * Required for Bootstrap 5 popovers to function correctly.
+ */
+
+function initializePopovers() {
+  const questDiv = moduleParams.questDiv;
+
+  [...questDiv.querySelectorAll('[data-bs-toggle="popover"]')].forEach(popoverTriggerEl => {
+    if (!bootstrap.Popover.getInstance(popoverTriggerEl)) {
+      new bootstrap.Popover(popoverTriggerEl);
+    }
+  });
 }
 
 // Check whether the browser supports "month" input type.


### PR DESCRIPTION
Updates from Mod 1 and COVID Survey testing

• Update `Popover` handling for Bootstrap 5 compatibility
• Keep text & responses out of `getKeyedValue()` (it's meant for keys with dot notation)
• Fix return of raw Concept IDs for empty 'Other' input field when fallback text isn't provided in survey markdown.